### PR TITLE
feat: support YAML configuration and configurable minification

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+)
+
+// KswConfig represents the application configuration.
+type KswConfig struct {
+	Kubeconfig KubeconfigConfig `json:"kubeconfig" yaml:"kubeconfig"`
+}
+
+// KubeconfigConfig holds configuration related to kubeconfig minification.
+type KubeconfigConfig struct {
+	Minify bool `json:"minify" yaml:"minify"`
+}
+
+var userHomeDir = os.UserHomeDir
+
+// loadConfig loads the configuration from ~/.config/ksw/config.yaml or falling back to ~/.ksw.yaml.
+func loadConfig() KswConfig {
+	home, err := userHomeDir()
+	if err != nil {
+		return KswConfig{
+			Kubeconfig: KubeconfigConfig{
+				Minify: false,
+			},
+		}
+	}
+
+	return loadConfigFromHome(home)
+}
+
+// loadConfigFromHome loads the configuration relative to a specific home directory.
+func loadConfigFromHome(home string) KswConfig {
+	cfg := KswConfig{
+		Kubeconfig: KubeconfigConfig{
+			Minify: false,
+		},
+	}
+
+	primaryPath := filepath.Join(home, ".config", "ksw", "config.yaml")
+	fallbackPath := filepath.Join(home, ".ksw.yaml")
+
+	var configBytes []byte
+
+	var readErr error
+
+	if _, err := os.Stat(primaryPath); err == nil {
+		configBytes, readErr = os.ReadFile(primaryPath)
+	} else if _, err := os.Stat(fallbackPath); err == nil {
+		configBytes, readErr = os.ReadFile(fallbackPath)
+	} else {
+		return cfg
+	}
+
+	if readErr != nil {
+		return cfg
+	}
+
+	var parsedCfg KswConfig
+
+	parsedCfg.Kubeconfig.Minify = false
+
+	if err := yaml.Unmarshal(configBytes, &parsedCfg); err != nil {
+		return cfg
+	}
+
+	return parsedCfg
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+func TestLoadConfig(t *testing.T) {
+	origUserHomeDir := userHomeDir
+
+	defer func() {
+		userHomeDir = origUserHomeDir
+	}()
+
+	tests := []struct {
+		name       string
+		homeSetup  func(t *testing.T, home string)
+		homeErr    error
+		wantMinify bool
+	}{
+		{
+			name:       "no config files - defaults to minify: false",
+			homeSetup:  func(t *testing.T, home string) {},
+			wantMinify: false,
+		},
+		{
+			name: "primary config file with minify: true",
+			homeSetup: func(t *testing.T, home string) {
+				configDir := filepath.Join(home, ".config", "ksw")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					t.Fatalf("Failed to create config dir: %v", err)
+				}
+
+				content := []byte("kubeconfig:\n  minify: true\n")
+				if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), content, 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			},
+			wantMinify: true,
+		},
+		{
+			name: "primary config file with minify: false",
+			homeSetup: func(t *testing.T, home string) {
+				configDir := filepath.Join(home, ".config", "ksw")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					t.Fatalf("Failed to create config dir: %v", err)
+				}
+
+				content := []byte("kubeconfig:\n  minify: false\n")
+				if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), content, 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			},
+			wantMinify: false,
+		},
+		{
+			name: "fallback config file with minify: true",
+			homeSetup: func(t *testing.T, home string) {
+				content := []byte("kubeconfig:\n  minify: true\n")
+				if err := os.WriteFile(filepath.Join(home, ".ksw.yaml"), content, 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			},
+			wantMinify: true,
+		},
+		{
+			name: "both files exist - primary takes precedence",
+			homeSetup: func(t *testing.T, home string) {
+				configDir := filepath.Join(home, ".config", "ksw")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					t.Fatalf("Failed to create config dir: %v", err)
+				}
+
+				if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("kubeconfig:\n  minify: true\n"), 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+
+				if err := os.WriteFile(filepath.Join(home, ".ksw.yaml"), []byte("kubeconfig:\n  minify: false\n"), 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			},
+			wantMinify: true,
+		},
+		{
+			name: "invalid YAML - defaults to minify: false",
+			homeSetup: func(t *testing.T, home string) {
+				content := []byte("kubeconfig: {\ninvalid yaml")
+				if err := os.WriteFile(filepath.Join(home, ".ksw.yaml"), content, 0600); err != nil {
+					t.Fatalf("Failed to write config file: %v", err)
+				}
+			},
+			wantMinify: false,
+		},
+		{
+			name:       "home dir lookup error - defaults to minify: false",
+			homeErr:    errors.New("home error"),
+			wantMinify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if tt.homeSetup != nil {
+				tt.homeSetup(t, tmpDir)
+			}
+
+			userHomeDir = func() (string, error) {
+				if tt.homeErr != nil {
+					return "", tt.homeErr
+				}
+
+				return tmpDir, nil
+			}
+
+			cfg := loadConfig()
+			if cfg.Kubeconfig.Minify != tt.wantMinify {
+				t.Errorf("loadConfig() Minify = %v, want %v", cfg.Kubeconfig.Minify, tt.wantMinify)
+			}
+		})
+	}
+}
+
+func TestGenerateKubeconfig_MinifyToggle(t *testing.T) {
+	origUserHomeDir := userHomeDir
+
+	defer func() {
+		userHomeDir = origUserHomeDir
+	}()
+
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "source-kubeconfig")
+
+	kubeconfigContent := `apiVersion: v1
+kind: Config
+current-context: dev-cluster
+contexts:
+- name: prod-cluster
+  context:
+    cluster: prod
+    user: prod-user
+- name: dev-cluster
+  context:
+    cluster: dev
+    user: dev-user
+clusters:
+- name: prod
+  cluster:
+    server: https://prod.example.com
+- name: dev
+  cluster:
+    server: https://dev.example.com
+users:
+- name: prod-user
+  user:
+    token: prod-token
+- name: dev-user
+  user:
+    token: dev-token
+`
+
+	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600); err != nil {
+		t.Fatalf("Failed to create test kubeconfig: %v", err)
+	}
+
+	homeDir := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(filepath.Join(homeDir, ".config", "ksw"), 0755); err != nil {
+		t.Fatalf("Failed to create home config directory: %v", err)
+	}
+
+	userHomeDir = func() (string, error) {
+		return homeDir, nil
+	}
+
+	t.Run("minify is true", func(t *testing.T) {
+		configContent := []byte("kubeconfig:\n  minify: true\n")
+		if err := os.WriteFile(filepath.Join(homeDir, ".config", "ksw", "config.yaml"), configContent, 0600); err != nil {
+			t.Fatalf("Failed to write config file: %v", err)
+		}
+
+		gotBytes, err := generateKubeconfig(kubeconfigPath, "prod-cluster")
+		if err != nil {
+			t.Fatalf("generateKubeconfig() error = %v", err)
+		}
+
+		var gotConfig apiv1.Config
+		if err := yaml.Unmarshal(gotBytes, &gotConfig); err != nil {
+			t.Fatalf("Failed to unmarshal generated kubeconfig: %v", err)
+		}
+
+		if gotConfig.CurrentContext != "prod-cluster" {
+			t.Errorf("expected CurrentContext 'prod-cluster', got '%s'", gotConfig.CurrentContext)
+		}
+
+		if len(gotConfig.Contexts) != 1 || gotConfig.Contexts[0].Name != "prod-cluster" {
+			t.Errorf("expected exactly 1 context 'prod-cluster', got context count: %d", len(gotConfig.Contexts))
+		}
+
+		if len(gotConfig.Clusters) != 1 || gotConfig.Clusters[0].Name != "prod" {
+			t.Errorf("expected exactly 1 cluster 'prod', got cluster count: %d", len(gotConfig.Clusters))
+		}
+
+		if len(gotConfig.AuthInfos) != 1 || gotConfig.AuthInfos[0].Name != "prod-user" {
+			t.Errorf("expected exactly 1 user 'prod-user', got user count: %d", len(gotConfig.AuthInfos))
+		}
+	})
+
+	t.Run("minify is false", func(t *testing.T) {
+		configContent := []byte("kubeconfig:\n  minify: false\n")
+		if err := os.WriteFile(filepath.Join(homeDir, ".config", "ksw", "config.yaml"), configContent, 0600); err != nil {
+			t.Fatalf("Failed to write config file: %v", err)
+		}
+
+		gotBytes, err := generateKubeconfig(kubeconfigPath, "prod-cluster")
+		if err != nil {
+			t.Fatalf("generateKubeconfig() error = %v", err)
+		}
+
+		var gotConfig apiv1.Config
+		if err := yaml.Unmarshal(gotBytes, &gotConfig); err != nil {
+			t.Fatalf("Failed to unmarshal generated kubeconfig: %v", err)
+		}
+
+		if gotConfig.CurrentContext != "prod-cluster" {
+			t.Errorf("expected CurrentContext 'prod-cluster', got '%s'", gotConfig.CurrentContext)
+		}
+
+		if len(gotConfig.Contexts) != 2 {
+			t.Errorf("expected 2 contexts, got %d", len(gotConfig.Contexts))
+		}
+
+		if len(gotConfig.Clusters) != 2 {
+			t.Errorf("expected 2 clusters, got %d", len(gotConfig.Clusters))
+		}
+
+		if len(gotConfig.AuthInfos) != 2 {
+			t.Errorf("expected 2 users, got %d", len(gotConfig.AuthInfos))
+		}
+	})
+}

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -70,12 +70,36 @@ func generateKubeconfig(sourcePath string, contextName string) ([]byte, error) {
 		return nil, err
 	}
 
-	miniConfig, err := minifyConfig(config, contextName)
-	if err != nil {
-		return nil, err
+	cfg := loadConfig()
+
+	var outputConfig *apiv1.Config
+
+	if cfg.Kubeconfig.Minify {
+		miniConfig, err := minifyConfig(config, contextName)
+		if err != nil {
+			return nil, err
+		}
+
+		outputConfig = miniConfig
+	} else {
+		contextExists := false
+
+		for _, context := range config.Contexts {
+			if context.Name == contextName {
+				contextExists = true
+				break
+			}
+		}
+
+		if !contextExists {
+			return nil, fmt.Errorf("context not found")
+		}
+
+		config.CurrentContext = contextName
+		outputConfig = &config
 	}
 
-	bytes, err := yaml.Marshal(miniConfig)
+	bytes, err := yaml.Marshal(outputConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR implements YAML configuration support and configurable kubeconfig minification as described in #40.

### Changes
- Added support for loading YAML config from `~/.config/ksw/config.yaml` (falling back to `~/.ksw.yaml`).
- Added `kubeconfig.minify` option (defaults to `false`).
- Updated kubeconfig generation to preserve all contexts/clusters/users and set `current-context` when `minify` is `false`.
- Added unit and integration tests covering the new config loading, defaults, precedence, and generation logic.

Closes #40
